### PR TITLE
Can view builds in the builds view based on the selected project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # cloudbuild-term
 Review Google Cloudbuilds in the terminal
 
+**Warning** This is an MVP as far as tools go. There's not much in the way of testing or mocking and it needs work. Use at your own risk.
+
 ## Why?
 
 Who wants to use a GUI to track down cloudbuilds when there could be many that are running concurrently across multiple projects?
 
-## Planned Features
+## How?
 
-- View cloudbuilds across one or many projects at once
-- Deep dive into builds or view at a high level
-- Use plugins to validate output, e.g. a Terraform plugin could simplify the build output or give a blast radius score?
+Ensure you are authorised to use Google APS in the terminal with `gcloud auth login` and `gcloud auth application-default login`
+
+It is allowing application-default credentials to use your login that provides access to the application.

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,8 @@ module github.com/Jake-Mok-Nelson/cloudbuild-term
 go 1.14
 
 require (
-	cloud.google.com/go v0.57.0
-	cloud.google.com/go/storage v1.6.0
 	github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3
-	github.com/jroimartin/gocui v0.4.0
+	github.com/awesome-gocui/gocui v0.6.1-0.20200609201851-b274208644a7
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 // indirect
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
+cloud.google.com/go v0.56.0 h1:WRz29PgAsVEyPSDHyk+0fpEkwEFyfhHn+JbksT6gIL4=
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0 h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
@@ -38,6 +39,12 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3 h1:LHEOGCi+2CooiWkQB2BlzdMVh6rdRDyt5Wflv4yzvXY=
 github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
+github.com/awesome-gocui/gocui v0.6.0 h1:hhDJiQC12tEsJNJ+iZBBVaSSLFYo9llFuYpQlL5JZVI=
+github.com/awesome-gocui/gocui v0.6.0/go.mod h1:1QikxFaPhe2frKeKvEwZEIGia3haiOxOUXKinrv17mA=
+github.com/awesome-gocui/gocui v0.6.1-0.20200609201851-b274208644a7 h1:FKqmvMoWUQUNCQCM5P8KCz9hokp8wN2gZNgLqNsPcYQ=
+github.com/awesome-gocui/gocui v0.6.1-0.20200609201851-b274208644a7/go.mod h1:g0pd2zYUkeeXck8lY+Idr8w1g1+RZSsRpFoEJSrGdUM=
+github.com/awesome-gocui/termbox-go v0.0.0-20190427202837-c0aef3d18bcc h1:wGNpKcHU8Aadr9yOzsT3GEsFLS7HQu8HxQIomnekqf0=
+github.com/awesome-gocui/termbox-go v0.0.0-20190427202837-c0aef3d18bcc/go.mod h1:tOy3o5Nf1bA17mnK4W41gD7PS3u4Cv0P0pqFcoWMy8s=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -67,6 +74,10 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
+github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-errors/errors v1.0.2 h1:xMxH9j2fNg/L4hLn/4y3M0IUsn0M6Wbu/Uh9QlOfBh4=
+github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -92,6 +103,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -168,6 +180,7 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -306,6 +319,7 @@ golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5 h1:WQ8q63x+f/zpC8Ac1s9wLElVoHhm32p6tudrU72n1QA=
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -347,6 +361,7 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e h1:hq86ru83GdWTlfQFZGO4nZJTU4Bs2wfHl8oFHRaXsfc=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -447,6 +462,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=

--- a/internal/builds/build_repository.go
+++ b/internal/builds/build_repository.go
@@ -15,7 +15,23 @@ func FetchBuilds(projectID string, limit int64) (builds []byte, err error) {
 	}
 
 	// Get builds for a given project
-	buildsList, err := cloudbuildService.Projects.Builds.List(projectID).PageSize(limit).Do()
+	buildsList, err := cloudbuildService.Projects.Builds.List(projectID).
+		Fields(
+			"builds/buildTriggerId",
+			"builds/logsBucket",
+			"builds/startTime",
+			"builds/finishTime",
+			"builds/id",
+			"builds/projectId",
+			"builds/results",
+			"builds/source",
+			"builds/status",
+			"builds/queueTtl",
+			"builds/statusDetail",
+			"builds/tags").
+		PageSize(limit).
+		Do()
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/builds/build_repository.go
+++ b/internal/builds/build_repository.go
@@ -23,7 +23,6 @@ func FetchBuilds(projectID string, limit int64) (builds []byte, err error) {
 			"builds/finishTime",
 			"builds/id",
 			"builds/projectId",
-			"builds/results",
 			"builds/source",
 			"builds/status",
 			"builds/queueTtl",

--- a/internal/builds/model.go
+++ b/internal/builds/model.go
@@ -2,6 +2,7 @@ package builds
 
 import "time"
 
+// BuildOverview - A high level view of a list of builds, for listing builds with minimal details
 type BuildOverview struct {
 	Builds []struct {
 		BuildTriggerID string    `json:"buildTriggerId"`
@@ -10,11 +11,7 @@ type BuildOverview struct {
 		LogsBucket     string    `json:"logsBucket"`
 		ProjectID      string    `json:"projectId"`
 		QueueTTL       string    `json:"queueTtl"`
-		Results        struct {
-			BuildStepImages  []string `json:"buildStepImages"`
-			BuildStepOutputs []string `json:"buildStepOutputs"`
-		} `json:"results"`
-		Source struct {
+		Source         struct {
 			RepoSource struct {
 				CommitSha string `json:"commitSha"`
 				ProjectID string `json:"projectId"`

--- a/internal/builds/model.go
+++ b/internal/builds/model.go
@@ -1,0 +1,28 @@
+package builds
+
+import "time"
+
+type BuildOverview struct {
+	Builds []struct {
+		BuildTriggerID string    `json:"buildTriggerId"`
+		FinishTime     time.Time `json:"finishTime"`
+		ID             string    `json:"id"`
+		LogsBucket     string    `json:"logsBucket"`
+		ProjectID      string    `json:"projectId"`
+		QueueTTL       string    `json:"queueTtl"`
+		Results        struct {
+			BuildStepImages  []string `json:"buildStepImages"`
+			BuildStepOutputs []string `json:"buildStepOutputs"`
+		} `json:"results"`
+		Source struct {
+			RepoSource struct {
+				CommitSha string `json:"commitSha"`
+				ProjectID string `json:"projectId"`
+				RepoName  string `json:"repoName"`
+			} `json:"repoSource"`
+		} `json:"source"`
+		StartTime time.Time `json:"startTime"`
+		Status    string    `json:"status"`
+		Tags      []string  `json:"tags"`
+	} `json:"builds"`
+}

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Jake-Mok-Nelson/cloudbuild-term/internal/builds"
-	"github.com/jroimartin/gocui"
+	"github.com/awesome-gocui/gocui"
 )
 
 func nextView(g *gocui.Gui, v *gocui.View) error {
@@ -73,7 +73,7 @@ func updateBuildsListView(g *gocui.Gui, project string) error {
 	}
 
 	// Fetch a list of builds for a given projectId
-	buildsData, err := builds.FetchBuilds(project, 2)
+	buildsData, err := builds.FetchBuilds(project, 10)
 	if err != nil {
 		return err
 	}
@@ -92,11 +92,13 @@ func updateBuildsListView(g *gocui.Gui, project string) error {
 	}
 
 	for _, val := range b.Builds {
-		fmt.Printf(val.BuildTriggerID, view)
+
+		fmt.Fprintln(view,
+			"Source: "+val.Source.RepoSource.RepoName+" Status: "+val.Status+" Commit: "+val.Source.RepoSource.CommitSha+" Start: "+val.StartTime.Local().String()+" Finish: "+val.FinishTime.Local().String(),
+		)
 
 	}
 
-	view.Write(buildsData)
 	// TODO: Print out the list of builds here
 
 	return nil

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -81,53 +81,23 @@ func updateBuildsListView(g *gocui.Gui, project string) error {
 	// Update the builds view with the output of the builds command
 	view.Clear()
 
-	// Creating the maps for JSON
-	m := map[string]interface{}{}
+	// // Creating the maps for JSON
+	// m := map[string]interface{}{}
+	b := builds.BuildOverview{}
 
-	// Parsing/Unmarshalling JSON encoding/json
-	err = json.Unmarshal([]byte(buildsData), &m)
+	// // Parsing/Unmarshalling JSON encoding/json
+	err = json.Unmarshal([]byte(buildsData), &b)
 	if err != nil {
 		return err
 	}
 
-	parseMap(m, view)
-	if err != nil {
-		return err
+	for _, val := range b.Builds {
+		fmt.Printf(val.BuildTriggerID, view)
+
 	}
+
+	view.Write(buildsData)
+	// TODO: Print out the list of builds here
 
 	return nil
-}
-
-func parseMap(aMap map[string]interface{}, v *gocui.View) {
-	for key, val := range aMap {
-		switch concreteVal := val.(type) {
-		case map[string]interface{}:
-			//fmt.Println(key)
-			fmt.Printf(key, v)
-
-			parseMap(val.(map[string]interface{}), v)
-		case []interface{}:
-			//fmt.Println(key)
-			fmt.Printf(key, v)
-			parseArray(val.([]interface{}), v)
-		default:
-			fmt.Println(key, ":", concreteVal)
-		}
-	}
-}
-
-func parseArray(anArray []interface{}, v *gocui.View) {
-	for i, val := range anArray {
-		switch concreteVal := val.(type) {
-		case map[string]interface{}:
-			fmt.Println("Index:", i)
-			parseMap(val.(map[string]interface{}), v)
-		case []interface{}:
-			fmt.Println("Index:", i)
-			parseArray(val.([]interface{}), v)
-		default:
-			fmt.Println("Index", i, ":", concreteVal)
-
-		}
-	}
 }

--- a/internal/gui/init.go
+++ b/internal/gui/init.go
@@ -4,12 +4,12 @@ import (
 	"log"
 
 	"github.com/asaskevich/EventBus"
-	"github.com/jroimartin/gocui"
+	"github.com/awesome-gocui/gocui"
 )
 
 // InitGUI - Initialise the gui
 func InitGUI(bus EventBus.Bus) {
-	g, err := gocui.NewGui(gocui.OutputNormal)
+	g, err := gocui.NewGui(gocui.OutputNormal, false)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/internal/gui/keybindings.go
+++ b/internal/gui/keybindings.go
@@ -1,6 +1,6 @@
 package gui
 
-import "github.com/jroimartin/gocui"
+import "github.com/awesome-gocui/gocui"
 
 // Keybindings - Keybindings for views in our layout
 func Keybindings(g *gocui.Gui) error {
@@ -13,7 +13,7 @@ func Keybindings(g *gocui.Gui) error {
 
 	// Keybindings for the projects view
 
-	if err := g.SetKeybinding("projects", gocui.KeyCtrlSpace, gocui.ModNone, nextView); err != nil {
+	if err := g.SetKeybinding("projects", gocui.KeyTab, gocui.ModNone, nextView); err != nil {
 		return err
 	}
 
@@ -31,7 +31,15 @@ func Keybindings(g *gocui.Gui) error {
 
 	// Keybindings for the builds view
 
-	if err := g.SetKeybinding("builds", gocui.KeyCtrlSpace, gocui.ModNone, nextView); err != nil {
+	if err := g.SetKeybinding("builds", gocui.KeyTab, gocui.ModNone, nextView); err != nil {
+		return err
+	}
+
+	if err := g.SetKeybinding("builds", gocui.KeyArrowDown, gocui.ModNone, cursorDown); err != nil {
+		return err
+	}
+
+	if err := g.SetKeybinding("builds", gocui.KeyArrowUp, gocui.ModNone, cursorUp); err != nil {
 		return err
 	}
 

--- a/internal/gui/layout.go
+++ b/internal/gui/layout.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Jake-Mok-Nelson/cloudbuild-term/internal/projects"
-	"github.com/jroimartin/gocui"
+	"github.com/awesome-gocui/gocui"
 )
 
 // Layout - The viusal layout of our application
@@ -12,35 +12,44 @@ func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
 	// HEADER VIEW
-	if v, err := g.SetView("header", -1, -1, maxX, 30); err != nil {
-		if err != gocui.ErrUnknownView {
+	if v, err := g.SetView("header", -1, -1, maxX, 90, 0); err != nil {
+		if !gocui.IsUnknownView(err) {
 			return err
 		}
-		v.Editable = true
+		v.Editable = false
+		v.FgColor = gocui.ColorBlue
+
 		v.Wrap = true
-		fmt.Fprintln(v, `
+
+		fmt.Fprint(v, `
      ___ _                 _ _           _ _     _   _____
     / __\ | ___  _   _  __| | |__  _   _(_) | __| | /__   \___ _ __ _ __ ___
-  / /  | |/ _ \| | | |/ _' | '_ \| | | | | |/ _' |   / /\/ _ \ '__| '_ ' _ \
+   / /  | |/ _ \| | | |/ _' | '_ \| | | | | |/ _' |   / /\/ _ \ '__| '_ ' _ \
   / /___| | (_) | |_| | (_| | |_) | |_| | | | (_| |  / / |  __/ |  | | | | | |
   \____/|_|\___/ \__,_|\__,_|_.__/ \__,_|_|_|\__,_|  \/   \___|_|  |_| |_| |_|
   `)
 
-		fmt.Fprint(v, "\n\n")
+		fmt.Fprint(v, "\n")
+		fmt.Fprintln(v, "KEYBINDINGS")
+		fmt.Fprintln(v, "Tab: Switch View         Enter: Select")
+		fmt.Fprintln(v, "↑↓: Change Selection     ^C: Exit")
+		fmt.Fprint(v, "\n")
+
 		if _, err := g.SetCurrentView("header"); err != nil {
 			return err
 		}
+
 	}
 
 	// PROJECTS VIEW
-	if v, err := g.SetView("projects", 0, 10, 30, maxY-1); err != nil {
-		if err != gocui.ErrUnknownView {
+	if v, err := g.SetView("projects", 0, 10, 30, maxY-1, 0); err != nil {
+		if !gocui.IsUnknownView(err) {
 			return err
 		}
 		v.Title = "Projects"
 		v.Highlight = true
-		v.SelBgColor = gocui.ColorGreen
-		v.SelFgColor = gocui.ColorBlack
+		v.SelBgColor = gocui.ColorBlue
+		v.SelFgColor = gocui.ColorWhite
 
 		p, err := projects.FetchProjects()
 		if err != nil {
@@ -53,12 +62,15 @@ func layout(g *gocui.Gui) error {
 	}
 
 	// BUILD STATUS VIEW
-	if v, err := g.SetView("builds", 31, 10, maxX-1, maxY-1); err != nil {
-		if err != gocui.ErrUnknownView {
+	if v, err := g.SetView("builds", 31, 10, maxX-1, maxY-1, 0); err != nil {
+		if !gocui.IsUnknownView(err) {
 			return err
 		}
 		v.Title = "Build Status"
-		v.Editable = false
+		v.Highlight = true
+		v.SelBgColor = gocui.ColorBlue
+		v.SelFgColor = gocui.ColorWhite
+
 		v.Wrap = true
 		if _, err := g.SetCurrentView("builds"); err != nil {
 			return err


### PR DESCRIPTION
Fixes #2 

Changes:

- Use filters to request smaller amounts of data

https://godoc.org/google.golang.org/api/googleapi#Field
By limiting the fields requested to only those that I actually need for the few I can make the builds list response from Google much smaller.

- Selectable builds in the builds view

They don't do anything yet but hey, they're selectable! Mission accomplished.
I've also switched to using a fork of the GUI framework because the original is dead.

- Switched to a community fork of gocui which is maintained

I had to use a specific commit rather than a release as there hasn't been a release in quite a while.

- Updated docs to cover some basics of how to use